### PR TITLE
do not send event if duration greater than 500 seconds

### DIFF
--- a/lib/NewRelic.js
+++ b/lib/NewRelic.js
@@ -6,7 +6,6 @@ var _moment=require('moment');var _moment2=_interopRequireDefault(_moment);funct
 var RNNewRelic=_reactNative.NativeModules.RNNewRelic;var
 
 NewRelic=function(){function NewRelic(){_classCallCheck(this,NewRelic);}_createClass(NewRelic,[{key:'init',value:function init(
-
 config){
 if(config.overrideConsole){
 this._overrideConsole();
@@ -104,9 +103,14 @@ argsStr[String(key)]=String(value);
 });
 var startingTime=this.startingTimes?this.startingTimes[name]:null;
 if(startingTime){
+var duration=(0,_moment2.default)().diff(startingTime)/1000;
+
+if(duration>500){
+return;
+}
 argsStr=_extends({},
 argsStr,{
-duration:(0,_moment2.default)().diff(startingTime)/1000});
+duration:duration});
 
 this.startingTimes[name]=null;
 }

--- a/src/NewRelic.js
+++ b/src/NewRelic.js
@@ -6,7 +6,6 @@ import moment from 'moment';
 const RNNewRelic = NativeModules.RNNewRelic;
 
 class NewRelic {
-
   init(config) {
     if (config.overrideConsole) {
       this._overrideConsole();
@@ -104,9 +103,14 @@ class NewRelic {
     });
     const startingTime = this.startingTimes ? this.startingTimes[name] : null;
     if (startingTime) {
+      const duration = moment().diff(startingTime) / 1000;
+      // Timeout of 500 seconds to account for timeEvent outliers
+      if (duration > 500) {
+        return;
+      }
       argsStr = {
         ...argsStr,
-        duration: moment().diff(startingTime) / 1000
+        duration
       };
       this.startingTimes[name] = null;
     }

--- a/test/NewRelic.spec.js
+++ b/test/NewRelic.spec.js
@@ -111,6 +111,20 @@ describe('NewRelic', () => {
       expect(mockNewRelic.send).toHaveBeenCalledWith(eventType, eventName, {userId: '1', duration: 10});
     });
 
+    it('does not send event if duration is over 500 seconds', () => {
+      const now = moment('2016-01-01').toDate();
+      jasmine.clock().mockDate(now);
+      const eventType = 'MyEventType';
+      const eventName = 'MyEvent';
+      spyOn(mockNewRelic, 'send');
+      uut.timeEvent(eventName);
+      expect(mockNewRelic.send).not.toHaveBeenCalled();
+      const later = moment(now).add(501, 's').toDate();
+      jasmine.clock().mockDate(later);
+      uut.send(eventType, eventName, {userId: 1});
+      expect(mockNewRelic.send).not.toHaveBeenCalled();
+    });
+
     it('does not add duration to args if no starting time present', () => {
       const eventType = 'MyEventType';
       const eventName1 = 'MyEvent';


### PR DESCRIPTION
Set a timeout of 500 seconds on a timeEvent to not send up crazy outliers