### PR TITLE
Support number in custom event

### DIFF
--- a/lib/NewRelic.js
+++ b/lib/NewRelic.js
@@ -99,7 +99,7 @@ var eventTypeStr=String(eventType);
 var nameStr=String(name);
 var argsStr={};
 _.forEach(args,function(value,key){
-argsStr[String(key)]=String(value);
+argsStr[String(key)]=value;
 });
 var startingTime=this.startingTimes?this.startingTimes[name]:null;
 if(startingTime){

--- a/lib/NewRelic.js
+++ b/lib/NewRelic.js
@@ -99,7 +99,11 @@ var eventTypeStr=String(eventType);
 var nameStr=String(name);
 var argsStr={};
 _.forEach(args,function(value,key){
-argsStr[String(key)]=value;
+if(typeof value==='number'){
+argsStr[String(key)]=Number(value);
+}else{
+argsStr[String(key)]=String(value);
+}
 });
 var startingTime=this.startingTimes?this.startingTimes[name]:null;
 if(startingTime){

--- a/src/NewRelic.js
+++ b/src/NewRelic.js
@@ -99,7 +99,7 @@ class NewRelic {
     const nameStr = String(name);
     let argsStr = {};
     _.forEach(args, (value, key) => {
-      argsStr[String(key)] = String(value);
+      argsStr[String(key)] = value;
     });
     const startingTime = this.startingTimes ? this.startingTimes[name] : null;
     if (startingTime) {

--- a/src/NewRelic.js
+++ b/src/NewRelic.js
@@ -99,7 +99,11 @@ class NewRelic {
     const nameStr = String(name);
     let argsStr = {};
     _.forEach(args, (value, key) => {
-      argsStr[String(key)] = value;
+      if (typeof value === 'number') {
+        argsStr[String(key)] = Number(value);
+      } else {
+        argsStr[String(key)] = String(value);
+      }
     });
     const startingTime = this.startingTimes ? this.startingTimes[name] : null;
     if (startingTime) {


### PR DESCRIPTION
In order to support number calculation on NewRelic, we check the incoming type and either cast to string or number